### PR TITLE
Feature/support btrfs 3.x; one kind of human readable (IEC)

### DIFF
--- a/btrfs-du
+++ b/btrfs-du
@@ -14,6 +14,34 @@
 # More at https://ownyourbits.com/2017/12/06/check-disk-space-of-your-btrfs-snapshots-with-btrfs-du/
 #
 
+# bytesToHuman based on https://unix.stackexchange.com/questions/44040/a-standard-tool-to-convert-a-byte-count-into-human-kib-mib-etc-like-du-ls1/259254#259254
+# units from wikipedia (note I had to re-order Z and Y):
+# - https://en.wikipedia.org/wiki/Binary_prefix
+# - https://en.wikipedia.org/wiki/File_size
+# - https://en.wikipedia.org/wiki/ISO/IEC_80000#Information_science_and_technology 
+# test cases from https://www.alteeve.com/w/IEC_and_SI_Size_Notations and https://en.wikipedia.org/wiki/File_size
+# 64-bibt checks at https://superuser.com/questions/1030122/what-is-the-maximum-value-of-a-numeric-bash-shell-variable/1030129#1030129
+
+bytesToHumanIEC() {
+    b=${1:-0}; d=''; s=0; S=(Bytes {K,M,G,T,E,P,Z,Y}iB)
+    while ((b > 1024)); do
+        d="$(printf ".%02d" $((b % 1024 * 100 / 1024)))"
+        b=$((b / 1024))
+        let s++
+    done
+    echo "$b$d${S[$s]}"
+}
+
+bytesToHumanSI() {
+    b=${1:-0}; d=''; s=0; S=(Bytes {k,M,G,T,E,P,Z,Y}B)
+    while ((b > 1000)); do
+        d="$(printf ".%02d" $((b % 1000 * 100 / 1000)))"
+        b=$((b / 1000))
+        let s++
+    done
+    echo "$b$d${S[$s]}"
+}
+
 LOCATION=${1:-/}
 
 # checks
@@ -32,6 +60,26 @@ LOCATION=${1:-/}
   exit 1
 }
 
+# determine if the '--raw' option is supported:
+_btrfs_qgroup_show_raw="btrfs qgroup show --raw"
+
+OUT=$( $_btrfs_qgroup_show_raw 2>&1)
+
+# If you want to depend on bash string matching, replace the below grep with this:
+#if [[ "$OUT" == *"unrecognized option"* ]]; then
+#  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
+#  _btrfs_qgroup_show_raw="btrfs qgroup show"
+#fi    
+    
+## This check fails to recognise the failure:    
+grep -q "unrecognized option" <<< "$OUT" && {
+  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
+  # not supported by "Btrfs v3.12+20131125" and likekly other legacy versions
+  # luckily "Btrfs v3.12+20131125" gives the same output without '--raw'
+  # as "btrfs-progs v4.13.3" does with '--raw'
+  _btrfs_qgroup_show_raw="btrfs qgroup show"
+}
+
 # quota management
 sync
 btrfs qgroup show "$LOCATION" 2>&1 | grep -q "quotas not enabled" && {
@@ -41,32 +89,12 @@ btrfs qgroup show "$LOCATION" 2>&1 | grep -q "quotas not enabled" && {
 
 # if we just enabled quota, might have to wait for rescan using 'btrfs qgroup show'
 
-# determine if the '--si' option is supported:
-_btrfs_qgroup_show_si="btrfs qgroup show --si --sort=qgroupid"
-
-OUT=$( $_btrfs_qgroup_show_si 2>&1)
-
-# If you want to depend on bash string matching, replace the below grep with this:
-#if [[ "$OUT" == *"unrecognized option"* ]]; then
-#  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--si'..."
-#  _btrfs_qgroup_show_si="btrfs qgroup show --sort=qgroupid"
-#fi    
-    
-## This check fails to recognise the failure:    
-grep -q "unrecognized option" <<< "$OUT" && {
-  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--si'..."
-  # not supported by "Btrfs v3.12+20131125" and likekly other legacy versions
-  # luckily "Btrfs v3.12+20131125" gives the same output without '--si'
-  # as "btrfs-progs v4.13.3" does with '--si'
-  _btrfs_qgroup_show_si="btrfs qgroup show --sort=qgroupid"
-}
-
-OUT=$( $_btrfs_qgroup_show_si "$LOCATION" 2>&1 )
+OUT=$( $_btrfs_qgroup_show_raw "$LOCATION" 2>&1 )
 grep -q -e "rescan is running" -e "data inconsistent" <<< "$OUT" && {
   echo "INFO: Quota is disabled. Waiting for rescan to finish ..."
   while true; do
     sleep 2
-    OUT=$( $_btrfs_qgroup_show_si "$LOCATION" 2>&1 )
+    OUT=$( $_btrfs_qgroup_show_raw "$LOCATION" 2>&1 )
     grep -q -e "rescan is running" -e "data inconsistent" <<< "$OUT" || break
   done
 }
@@ -81,8 +109,10 @@ TOT_=( $( awk '{ print $2 }' <<< "$OUT" ) )
 EXC_=( $( awk '{ print $3 }' <<< "$OUT" ) )
 
 for (( i = 0 ; i < ${#ID__[@]} ; i++ )); do
-  TOT[${ID__[$i]}]=${TOT_[$i]}
-  EXC[${ID__[$i]}]=${EXC_[$i]}
+#  TOT[${ID__[$i]}]=${TOT_[$i]}
+#  EXC[${ID__[$i]}]=${EXC_[$i]}
+  TOT[${ID__[$i]}]=$( bytesToHumanIEC ${TOT_[$i]} )
+  EXC[${ID__[$i]}]=$( bytesToHumanIEC ${EXC_[$i]} )
 done
 
 ## naming data
@@ -94,47 +124,26 @@ for (( i = 0 ; i < ${#ID__[@]} ; i++ )); do
   NAME[${ID__[$i]}]=${NAM_[$i]}
 done
 
-# determine if the '--raw' option is supported:
-_btrfs_qgroup_show_raw="btrfs qgroup show --raw"
-
-EXCL_RAW=$( $_btrfs_qgroup_show_raw 2>&1)
-
-# If you want to depend on bash string matching, replace the below grep with this:
-#if [[ "$EXCL_RAW" == *"unrecognized option"* ]]; then
-#  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
-#  _btrfs_qgroup_show_raw="btrfs qgroup show"
-#fi    
-    
-## This check fails to recognise the failure:    
-grep -q "unrecognized option" <<< "$EXCL_RAW" && {
-  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
-  # not supported by "Btrfs v3.12+20131125" and likekly other legacy versions
-  # luckily "Btrfs v3.12+20131125" gives the same output without '--raw'
-  # as "btrfs-progs v4.13.3" does with '--raw'
-  _btrfs_qgroup_show_raw="btrfs qgroup show"
-}
-
 EXCL_RAW=( $( $_btrfs_qgroup_show_raw "$LOCATION" | sed '1,2d' | awk '{  print $3 }' ) )
 EXCL_TOTAL=0
 
 [[ "$QFLAG" == "1" ]] && btrfs quota disable "$LOCATION"
 
 # output
-printf "%-60s %-10s %-10s %-10s\n" "Subvolume" "Total" "Exclusive" "ID"
+printf "%-60s %10s %10s  %-10s\n" "Subvolume" "Total" "Exclusive" "ID"
 printf "─────────────────────────────────────────────────────────────────────────────────────────\n"
 
 ## matching by IDs in btrfs subvolume list
 for (( i = 0 ; i < ${#ID__[@]} ; i++ )); do
-  printf "%-60s %-10s %-10s %-10s\n" ${NAME[${ID__[$i]}]} ${TOT[${ID__[$i]}]} ${EXC[${ID__[$i]}]} ${ID__[$i]}
+  printf "%-60s %10s %10s  %-10s\n" ${NAME[${ID__[$i]}]} "${TOT[${ID__[$i]}]}" "${EXC[${ID__[$i]}]}" ${ID__[$i]}
   EXCL_TOTAL=$(( EXCL_TOTAL + ${EXCL_RAW[$i]} ))
 done
 
-EXCL_TOTAL=$( awk '{ sum=$1 ; hum[1024^4]="TB";hum[1024^3]="GB";hum[1024^2]="MB";hum[1024]="KB";
-              for (x=1024^4; x>=1024; x/=1024){ if (sum>=x) { printf "%.2f%s\n",sum/x,hum[x];break } }}' \
-              <<< "$EXCL_TOTAL" )
+#EXCL_TOTAL=$( bytesToHumanSI "$EXCL_TOTAL" )
+EXCL_TOTAL=$( bytesToHumanIEC "$EXCL_TOTAL" )
 
 printf "─────────────────────────────────────────────────────────────────────────────────────────\n"
-printf "%86s\n" "Total exclusive data: $EXCL_TOTAL"
+printf "%-60s %10s %10s  %-10s\n" "Total exclusive data:" "" "$EXCL_TOTAL" ""
 
 # License
 #

--- a/btrfs-du
+++ b/btrfs-du
@@ -39,13 +39,34 @@ btrfs qgroup show "$LOCATION" 2>&1 | grep -q "quotas not enabled" && {
   btrfs quota enable "$LOCATION"
 }
 
-# if we just enabled quota, might have to wait for rescan
-OUT=$( btrfs qgroup show --si --sort=qgroupid "$LOCATION" 2>&1 )
+# if we just enabled quota, might have to wait for rescan using 'btrfs qgroup show'
+
+# determine if the '--si' option is supported:
+_btrfs_qgroup_show_si="btrfs qgroup show --si --sort=qgroupid"
+
+OUT=$( $_btrfs_qgroup_show_si 2>&1)
+
+# If you want to depend on bash string matching, replace the below grep with this:
+#if [[ "$OUT" == *"unrecognized option"* ]]; then
+#  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--si'..."
+#  _btrfs_qgroup_show_si="btrfs qgroup show --sort=qgroupid"
+#fi    
+    
+## This check fails to recognise the failure:    
+grep -q "unrecognized option" <<< "$OUT" && {
+  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--si'..."
+  # not supported by "Btrfs v3.12+20131125" and likekly other legacy versions
+  # luckily "Btrfs v3.12+20131125" gives the same output without '--si'
+  # as "btrfs-progs v4.13.3" does with '--si'
+  _btrfs_qgroup_show_si="btrfs qgroup show --sort=qgroupid"
+}
+
+OUT=$( $_btrfs_qgroup_show_si "$LOCATION" 2>&1 )
 grep -q -e "rescan is running" -e "data inconsistent" <<< "$OUT" && {
   echo "INFO: Quota is disabled. Waiting for rescan to finish ..."
   while true; do
     sleep 2
-    OUT=$( btrfs qgroup show --si --sort=qgroupid "$LOCATION" 2>&1 )
+    OUT=$( $_btrfs_qgroup_show_si "$LOCATION" 2>&1 )
     grep -q -e "rescan is running" -e "data inconsistent" <<< "$OUT" || break
   done
 }
@@ -73,7 +94,27 @@ for (( i = 0 ; i < ${#ID__[@]} ; i++ )); do
   NAME[${ID__[$i]}]=${NAM_[$i]}
 done
 
-EXCL_RAW=( $( btrfs qgroup show --raw "$LOCATION" | sed '1,2d' | awk '{  print $3 }' ) )
+# determine if the '--raw' option is supported:
+_btrfs_qgroup_show_raw="btrfs qgroup show --raw"
+
+EXCL_RAW=$( $_btrfs_qgroup_show_raw 2>&1)
+
+# If you want to depend on bash string matching, replace the below grep with this:
+#if [[ "$EXCL_RAW" == *"unrecognized option"* ]]; then
+#  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
+#  _btrfs_qgroup_show_raw="btrfs qgroup show"
+#fi    
+    
+## This check fails to recognise the failure:    
+grep -q "unrecognized option" <<< "$EXCL_RAW" && {
+  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
+  # not supported by "Btrfs v3.12+20131125" and likekly other legacy versions
+  # luckily "Btrfs v3.12+20131125" gives the same output without '--raw'
+  # as "btrfs-progs v4.13.3" does with '--raw'
+  _btrfs_qgroup_show_raw="btrfs qgroup show"
+}
+
+EXCL_RAW=( $( $_btrfs_qgroup_show_raw "$LOCATION" | sed '1,2d' | awk '{  print $3 }' ) )
 EXCL_TOTAL=0
 
 [[ "$QFLAG" == "1" ]] && btrfs quota disable "$LOCATION"

--- a/btrfs-du
+++ b/btrfs-du
@@ -14,29 +14,14 @@
 # More at https://ownyourbits.com/2017/12/06/check-disk-space-of-your-btrfs-snapshots-with-btrfs-du/
 #
 
-# bytesToHuman based on https://unix.stackexchange.com/questions/44040/a-standard-tool-to-convert-a-byte-count-into-human-kib-mib-etc-like-du-ls1/259254#259254
-# units from wikipedia (note I had to re-order Z and Y):
-# - https://en.wikipedia.org/wiki/Binary_prefix
-# - https://en.wikipedia.org/wiki/File_size
-# - https://en.wikipedia.org/wiki/ISO/IEC_80000#Information_science_and_technology 
-# test cases from https://www.alteeve.com/w/IEC_and_SI_Size_Notations and https://en.wikipedia.org/wiki/File_size
-# 64-bibt checks at https://superuser.com/questions/1030122/what-is-the-maximum-value-of-a-numeric-bash-shell-variable/1030129#1030129
+# bytesToHumanIEC based on https://unix.stackexchange.com/questions/44040/a-standard-tool-to-convert-a-byte-count-into-human-kib-mib-etc-like-du-ls1/259254#259254
+# both bytesToHumanIEC, an SI implementatation and test cases for both are at https://gist.github.com/jpluimers/0f21bf1d937fe0b9b4044f21944a90ec
 
 bytesToHumanIEC() {
     b=${1:-0}; d=''; s=0; S=(Bytes {K,M,G,T,E,P,Z,Y}iB)
     while ((b > 1024)); do
         d="$(printf ".%02d" $((b % 1024 * 100 / 1024)))"
         b=$((b / 1024))
-        let s++
-    done
-    echo "$b$d${S[$s]}"
-}
-
-bytesToHumanSI() {
-    b=${1:-0}; d=''; s=0; S=(Bytes {k,M,G,T,E,P,Z,Y}B)
-    while ((b > 1000)); do
-        d="$(printf ".%02d" $((b % 1000 * 100 / 1000)))"
-        b=$((b / 1000))
         let s++
     done
     echo "$b$d${S[$s]}"
@@ -61,23 +46,16 @@ LOCATION=${1:-/}
 }
 
 # determine if the '--raw' option is supported:
-_btrfs_qgroup_show_raw="btrfs qgroup show --raw"
+btrfs_qgroup_show_raw="btrfs qgroup show --raw"
 
-OUT=$( $_btrfs_qgroup_show_raw 2>&1)
+OUT=$( $btrfs_qgroup_show_raw 2>&1 )
 
-# If you want to depend on bash string matching, replace the below grep with this:
-#if [[ "$OUT" == *"unrecognized option"* ]]; then
-#  echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
-#  _btrfs_qgroup_show_raw="btrfs qgroup show"
-#fi    
-    
-## This check fails to recognise the failure:    
 grep -q "unrecognized option" <<< "$OUT" && {
   echo "INFO: Legacy btrfs version; trying 'btrfs qgroup show' without '--raw'..."
   # not supported by "Btrfs v3.12+20131125" and likekly other legacy versions
   # luckily "Btrfs v3.12+20131125" gives the same output without '--raw'
   # as "btrfs-progs v4.13.3" does with '--raw'
-  _btrfs_qgroup_show_raw="btrfs qgroup show"
+  btrfs_qgroup_show_raw="btrfs qgroup show"
 }
 
 # quota management
@@ -89,12 +67,12 @@ btrfs qgroup show "$LOCATION" 2>&1 | grep -q "quotas not enabled" && {
 
 # if we just enabled quota, might have to wait for rescan using 'btrfs qgroup show'
 
-OUT=$( $_btrfs_qgroup_show_raw "$LOCATION" 2>&1 )
+OUT=$( $btrfs_qgroup_show_raw "$LOCATION" 2>&1 )
 grep -q -e "rescan is running" -e "data inconsistent" <<< "$OUT" && {
   echo "INFO: Quota is disabled. Waiting for rescan to finish ..."
   while true; do
     sleep 2
-    OUT=$( $_btrfs_qgroup_show_raw "$LOCATION" 2>&1 )
+    OUT=$( $btrfs_qgroup_show_raw "$LOCATION" 2>&1 )
     grep -q -e "rescan is running" -e "data inconsistent" <<< "$OUT" || break
   done
 }
@@ -109,8 +87,6 @@ TOT_=( $( awk '{ print $2 }' <<< "$OUT" ) )
 EXC_=( $( awk '{ print $3 }' <<< "$OUT" ) )
 
 for (( i = 0 ; i < ${#ID__[@]} ; i++ )); do
-#  TOT[${ID__[$i]}]=${TOT_[$i]}
-#  EXC[${ID__[$i]}]=${EXC_[$i]}
   TOT[${ID__[$i]}]=$( bytesToHumanIEC ${TOT_[$i]} )
   EXC[${ID__[$i]}]=$( bytesToHumanIEC ${EXC_[$i]} )
 done
@@ -124,26 +100,27 @@ for (( i = 0 ; i < ${#ID__[@]} ; i++ )); do
   NAME[${ID__[$i]}]=${NAM_[$i]}
 done
 
-EXCL_RAW=( $( $_btrfs_qgroup_show_raw "$LOCATION" | sed '1,2d' | awk '{  print $3 }' ) )
 EXCL_TOTAL=0
 
 [[ "$QFLAG" == "1" ]] && btrfs quota disable "$LOCATION"
 
+formatMask="%-60s %10s %10s  %-10s\n"
+separatorLine="─────────────────────────────────────────────────────────────────────────────────────────\n"
+
 # output
-printf "%-60s %10s %10s  %-10s\n" "Subvolume" "Total" "Exclusive" "ID"
-printf "─────────────────────────────────────────────────────────────────────────────────────────\n"
+printf "$formatMask" "Subvolume" "Total" "Exclusive" "ID"
+printf "$separatorLine"
 
 ## matching by IDs in btrfs subvolume list
 for (( i = 0 ; i < ${#ID__[@]} ; i++ )); do
-  printf "%-60s %10s %10s  %-10s\n" ${NAME[${ID__[$i]}]} "${TOT[${ID__[$i]}]}" "${EXC[${ID__[$i]}]}" ${ID__[$i]}
-  EXCL_TOTAL=$(( EXCL_TOTAL + ${EXCL_RAW[$i]} ))
+  printf "$formatMask" ${NAME[${ID__[$i]}]} "${TOT[${ID__[$i]}]}" "${EXC[${ID__[$i]}]}" ${ID__[$i]}
+  EXCL_TOTAL=$(( EXCL_TOTAL + ${EXC_[$i]} ))
 done
 
-#EXCL_TOTAL=$( bytesToHumanSI "$EXCL_TOTAL" )
 EXCL_TOTAL=$( bytesToHumanIEC "$EXCL_TOTAL" )
 
-printf "─────────────────────────────────────────────────────────────────────────────────────────\n"
-printf "%-60s %10s %10s  %-10s\n" "Total exclusive data:" "" "$EXCL_TOTAL" ""
+printf "$separatorLine"
+printf "$formatMask" "Total exclusive data:" "" "$EXCL_TOTAL" ""
 
 # License
 #


### PR DESCRIPTION
1. supports legacy btrfs (3.x, tested with `Btrfs v3.12+20131125`);  
   fixes https://github.com/nachoparker/btrfs-du/issues/4
2. refactored the mix of [human readable SI and IEC units](https://en.wikipedia.org/wiki/File_size) into just IEC units (more consistent with default `btrfs` behaviour, but also needed to complete 1.);  
   fixes https://github.com/nachoparker/btrfs-du/issues/1
3. various code cleanups and formatting of output (right align numbers, total line indentation same data lines so easier spreadsheet "split fixed format")

For comparison the outputs of a `btrfs-progs v4.13.3` system

Original:

```
# ~/Versioned/btrfs-du/btrfs-du
Subvolume                                                    Total      Exclusive  ID        
─────────────────────────────────────────────────────────────────────────────────────────
.snapshots                                                   2.06MB     2.06MB     257       
.snapshots/1/snapshot                                        4.38GB     149.70MB   258       
boot/grub2/i386-pc                                           2.49MB     2.49MB     259       
boot/grub2/x86_64-efi                                        16.38kB    16.38kB    260       
opt                                                          40.20MB    40.20MB    261       
srv                                                          499.71MB   499.71MB   262       
tmp                                                          2.85MB     2.85MB     263       
usr/local                                                    266.24kB   266.24kB   264       
var/crash                                                    16.38kB    16.38kB    265       
var/lib/mailman                                              32.77kB    32.77kB    266       
var/lib/named                                                37.68MB    37.68MB    267       
var/lib/pgsql                                                16.38kB    16.38kB    268       
var/log                                                      345.10MB   345.10MB   269       
var/opt                                                      16.38kB    16.38kB    270       
var/spool                                                    90.11kB    90.11kB    271       
var/tmp                                                      106.50kB   106.50kB   272       
var/lib/machines                                             16.38kB    16.38kB    797       
.snapshots/642/snapshot                                      4.35GB     863.06MB   1191      
.snapshots/643/snapshot                                      4.70GB     66.04MB    1195      
.snapshots/644/snapshot                                      4.36GB     14.84MB    1212      
.snapshots/645/snapshot                                      4.43GB     64.61MB    1216      
.snapshots/646/snapshot                                      4.38GB     6.77MB     1231      
.snapshots/647/snapshot                                      4.69GB     16.48MB    1232      
.snapshots/648/snapshot                                      4.68GB     16.77MB    1234      
.snapshots/649/snapshot                                      5.04GB     97.80MB    1237      
.snapshots/650/snapshot                                      4.39GB     20.01MB    1238      
.snapshots/651/snapshot                                      4.41GB     29.52MB    1239      
─────────────────────────────────────────────────────────────────────────────────────────
                                                          Total exclusive data: 2.09GB
```

Reformatted:

```
# ~/Versioned/btrfs-du/btrfs-du
Subvolume                                                         Total  Exclusive  ID        
─────────────────────────────────────────────────────────────────────────────────────────
.snapshots                                                      1.96MiB    1.96MiB  257       
.snapshots/1/snapshot                                           4.08GiB  142.80MiB  258       
boot/grub2/i386-pc                                              2.37MiB    2.37MiB  259       
boot/grub2/x86_64-efi                                          16.00KiB   16.00KiB  260       
opt                                                            38.33MiB   38.33MiB  261       
srv                                                           476.56MiB  476.56MiB  262       
tmp                                                             2.71MiB    2.71MiB  263       
usr/local                                                     260.00KiB  260.00KiB  264       
var/crash                                                      16.00KiB   16.00KiB  265       
var/lib/mailman                                                32.00KiB   32.00KiB  266       
var/lib/named                                                  35.93MiB   35.93MiB  267       
var/lib/pgsql                                                  16.00KiB   16.00KiB  268       
var/log                                                       329.10MiB  329.10MiB  269       
var/opt                                                        16.00KiB   16.00KiB  270       
var/spool                                                      88.00KiB   88.00KiB  271       
var/tmp                                                       104.00KiB  104.00KiB  272       
var/lib/machines                                               16.00KiB   16.00KiB  797       
.snapshots/642/snapshot                                         4.04GiB  823.08MiB  1191      
.snapshots/643/snapshot                                         4.37GiB   62.97MiB  1195      
.snapshots/644/snapshot                                         4.06GiB   14.15MiB  1212      
.snapshots/645/snapshot                                         4.12GiB   61.61MiB  1216      
.snapshots/646/snapshot                                         4.07GiB    6.46MiB  1231      
.snapshots/647/snapshot                                         4.36GiB   15.71MiB  1232      
.snapshots/648/snapshot                                         4.35GiB   15.99MiB  1234      
.snapshots/649/snapshot                                         4.69GiB   93.27MiB  1237      
.snapshots/650/snapshot                                         4.08GiB   19.08MiB  1238      
.snapshots/651/snapshot                                         4.10GiB   28.16MiB  1239      
─────────────────────────────────────────────────────────────────────────────────────────
Total exclusive data:                                                      2.09GiB 
```